### PR TITLE
Parameterize deployment strategy type

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "0.10.554.0"
 description: API Support for your favorite torrent trackers.
 name: jackett
 icon: https://raw.githubusercontent.com/Jackett/Jackett/master/src/Jackett.Common/Content/jacket_medium.png
-version: 0.1.1
+version: 0.1.2
 keywords:
   - jackett
 home: https://github.com/Jackett/Jackett

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -9,6 +9,8 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: {{ .Values.strategyType }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "jackett.name" . }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -9,8 +9,13 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
+{{- if .Values.strategy }}
   strategy:
-    type: {{ .Values.strategyType }}
+{{ toYaml .Values.strategy | indent 4 }}
+{{ if eq .Values.strategy.type "Recreate" }}
+    rollingUpdate: null
+{{- end }}
+{{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "jackett.name" . }}

--- a/values.yaml
+++ b/values.yaml
@@ -4,7 +4,8 @@
 
 replicaCount: 1
 
-strategyType: Recreate
+strategy: 
+  type: Recreate
 
 image:
   repository: linuxserver/jackett

--- a/values.yaml
+++ b/values.yaml
@@ -4,6 +4,8 @@
 
 replicaCount: 1
 
+strategyType: Recreate
+
 image:
   repository: linuxserver/jackett
   tag: latest


### PR DESCRIPTION
Hi, I've installed jackett using your chart, and as I'm using a pv with RWO access mode, pod refuses to be created as it cant mount previosuly used volume. That's the reason of this PR

  